### PR TITLE
Local replica support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 lambda.zip
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.54",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,7 +486,7 @@ dependencies = [
  "lazy_static",
  "regex",
  "serde",
- "strsim",
+ "strsim 0.9.3",
 ]
 
 [[package]]
@@ -751,6 +783,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +967,7 @@ name = "ic-http-lambda"
 version = "0.1.0"
 dependencies = [
  "candid",
+ "clap",
  "delay",
  "futures 0.3.8",
  "http 0.1.21",
@@ -1454,6 +1496,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "os_str_bytes"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
+
+[[package]]
 name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,6 +1662,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
  "toml",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.54",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "version_check",
 ]
 
 [[package]]
@@ -2083,6 +2155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2146,6 +2224,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -2549,6 +2636,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2600,6 +2693,12 @@ name = "utf8-ranges"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ candid = "^0.6.11"
 serde = "^1.0"
 futures = "0.3"
 delay = "0.3.0"
+clap = "3.0.0-beta.2"
 
 [patch.crates-io]
 ic-agent = { git = "https://github.com/nomeata/agent-rs", branch = "joachim/musl-hacks" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
-
 // The main function used with lambda
+
+use clap::{App, Arg};
 
 #[cfg(feature = "with-lambda")]
 use lambda_http::{lambda, IntoResponse};
@@ -10,11 +11,29 @@ fn main() {
         request: lambda_http::Request,
         _context: lambda_runtime::Context,
     ) -> Result<impl IntoResponse, lambda_runtime::error::HandlerError> {
+        let matches = App::new("ic-http-lambda")
+            .args(&[Arg::new("force-canister-id")
+                .about("Sets the canister id to use instead of parsing from the url.")
+                .takes_value(true)
+                .short('c')
+                .long("force-canister-id")
+                .default_value("")])
+            .args(&[Arg::new("replica-url")
+                .about("Sets the url for the running replica to forward requests to.")
+                .takes_value(true)
+                .short('r')
+                .long("replica-url")
+                .default_value("https://gw.dfinity.network")])
+            .get_matches();
+        let force_canister_id = matches.value_of("force-canister-id").unwrap();
+        let replica_url = matches.value_of("replica_url").unwrap();
         let response_builder = simple_server::ResponseBuilder::new();
         let mut rt = tokio::runtime::Runtime::new().unwrap();
         let resp = rt.block_on(handle(
             request.map(|b| b.as_ref().to_vec()),
             response_builder,
+            force_canister_id,
+            replica_url,
         ));
         resp.or_else(|e| {
             println!("Error: {}", e);
@@ -33,16 +52,34 @@ fn main() {
 fn main() {
     // env_logger::init().unwrap();
 
+    let matches = App::new("ic-http-lambda")
+        .args(&[Arg::new("force-canister-id")
+            .about("Sets the canister id to use instead of parsing from the url.")
+            .takes_value(true)
+            .short('c')
+            .long("force-canister-id")
+            .default_value("")])
+        .args(&[Arg::new("replica-url")
+            .about("Sets the url for the running replica to forward requests to.")
+            .takes_value(true)
+            .short('r')
+            .long("replica-url")
+            .default_value("https://gw.dfinity.network")])
+        .get_matches();
+    let force_canister_id = matches.value_of("force-canister-id").unwrap().to_string();
+    let replica_url = matches.value_of("replica-url").unwrap().to_string();
+
     let host = "127.0.0.1";
     let port = "7878";
 
-    let server = simple_server::Server::new(|request, response| {
+    let server = simple_server::Server::new(move |request, response| {
         let mut rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(handle(request, response)).or_else(|e| {
-            Ok(simple_server::ResponseBuilder::new()
-                .body(format!("{}", e).as_bytes().to_vec())
-                .unwrap())
-        })
+        rt.block_on(handle(request, response, &force_canister_id, &replica_url))
+            .or_else(|e| {
+                Ok(simple_server::ResponseBuilder::new()
+                    .body(format!("{}", e).as_bytes().to_vec())
+                    .unwrap())
+            })
     });
 
     println!("Running on http://{}:{}/", host, port);
@@ -78,28 +115,33 @@ struct HTTPResult {
 async fn handle(
     request: http::Request<Vec<u8>>,
     mut response: simple_server::ResponseBuilder,
+    force_canister_id: &str,
+    replica_url: &str,
 ) -> Result<http::Response<Vec<u8>>, Box<dyn Send + Sync + std::error::Error>> {
-    let url = "https://gw.dfinity.network";
-
     println!("Uri: {}", request.uri());
     println!("Request: {:?}", String::from_utf8_lossy(request.body()));
 
-    let cid = match request
-        .uri()
-        .host()
-        .and_then(|h| h.strip_suffix(".ic.nomeata.de").map(|x| x.to_owned()))
-        .and_then(|cid| ic_types::Principal::from_text(cid).ok())
-    {
-        Some(cid) => cid,
-        None => {
-            return Err(
-                format!("Use https://<cid>ic.nomeata.de/!\n(got: {})", request.uri()).into(),
-            )
-        }
-    };
+    let cid: ic_types::Principal;
+    if !force_canister_id.is_empty() {
+        cid = ic_types::Principal::from_text(force_canister_id).unwrap();
+    } else {
+        cid = match request
+            .uri()
+            .host()
+            .and_then(|h| h.strip_suffix(".ic.nomeata.de").map(|x| x.to_owned()))
+            .and_then(|c| ic_types::Principal::from_text(c).ok())
+        {
+            Some(c) => c,
+            None => {
+                return Err(
+                    format!("Use https://<cid>ic.nomeata.de/!\n(got: {})", request.uri()).into(),
+                )
+            }
+        };
+    }
 
     let agent = ic_agent::Agent::builder()
-        .with_url(url)
+        .with_url(replica_url)
         .build()
         .map_err(|e| Box::new(e))?;
     let req = HTTPRequest {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 // The main function used with lambda
 
+#[cfg(not(feature = "with-lambda"))]
 use clap::{App, Arg};
 
 #[cfg(feature = "with-lambda")]
@@ -11,29 +12,13 @@ fn main() {
         request: lambda_http::Request,
         _context: lambda_runtime::Context,
     ) -> Result<impl IntoResponse, lambda_runtime::error::HandlerError> {
-        let matches = App::new("ic-http-lambda")
-            .args(&[Arg::new("force-canister-id")
-                .about("Sets the canister id to use instead of parsing from the url.")
-                .takes_value(true)
-                .short('c')
-                .long("force-canister-id")
-                .default_value("")])
-            .args(&[Arg::new("replica-url")
-                .about("Sets the url for the running replica to forward requests to.")
-                .takes_value(true)
-                .short('r')
-                .long("replica-url")
-                .default_value("https://gw.dfinity.network")])
-            .get_matches();
-        let force_canister_id = matches.value_of("force-canister-id").unwrap();
-        let replica_url = matches.value_of("replica_url").unwrap();
         let response_builder = simple_server::ResponseBuilder::new();
         let mut rt = tokio::runtime::Runtime::new().unwrap();
         let resp = rt.block_on(handle(
             request.map(|b| b.as_ref().to_vec()),
             response_builder,
-            force_canister_id,
-            replica_url,
+            "",
+            "https://gw.dfinity.network",
         ));
         resp.or_else(|e| {
             println!("Error: {}", e);


### PR DESCRIPTION
Adds two command line args, `force-canister-id` and `replica-url`, which allow you to specify the canister to forward requests to (if this is specified, the canister id in the url will be ignored) and the url for the replica where the canister is running.

This does work properly for locally running replicas but I haven't tested that it still works with replicas on the network, though I don't expect my changes to cause any issue there. Leaving out the new args should cause no change in behavior.

This is the first Rust code I've ever written, and I had to cut a few corners to get it to compile. Surely it can be cleaned up, but for the life of me I couldn't figure out how to get it to compile after refactoring it to look nice. For example, the arg-parsing code is duplicated, once for each main function. Also, I had to add `move` to the `simple_server::Server::new` call on line 75 to get around a compilation error. Not sure exactly why, but I couldn't figure out how to get it to compile without it.