### PR TITLE
Increase upgraded timeout to 45s

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,7 @@ async fn handle(
         agent.fetch_root_key().await?;
         let waiter = delay::Delay::builder()
             .throttle(std::time::Duration::from_millis(500))
-            .timeout(std::time::Duration::from_secs(5))
+            .timeout(std::time::Duration::from_secs(45))
             .build();
 
         let result_blob = agent


### PR DESCRIPTION
Allow upgraded calls 45 seconds to succeed, as they often (always?) can't complete in only 5 seconds due to being non-query calls.