### PR TITLE
Fix for compiling on a mac

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-musl]
+linker = "x86_64-linux-musl-gcc"

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,7 @@ async fn handle(
         agent.fetch_root_key().await?;
         let waiter = delay::Delay::builder()
             .throttle(std::time::Duration::from_millis(500))
-            .timeout(std::time::Duration::from_secs(5))
+            .timeout(std::time::Duration::from_secs(45))
             .build();
 
         let result_blob = agent


### PR DESCRIPTION
I was getting the following error when running the ./deploy.sh script:
```
error: linking with `cc` failed: exit code: 1
...
ld: unknown option: --as-needed
 clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

The relevant section from [this walkthrough](https://aws.amazon.com/blogs/opensource/rust-runtime-for-aws-lambda/) informed me that:

```
we need to inform Cargo that our project uses the newly-installed linker when building for the x86_64-unknown-linux-musl
```

Even though the deploy.sh script specifies the correct platform, the build wouldn't succeed for me until I created the config file in this PR. I also had to create a symlink as suggested in the walkthrough:

`ln -s /usr/local/bin/x86_64-linux-musl-gcc /usr/local/bin/musl-gcc`